### PR TITLE
회원정보 수정 기능 추가

### DIFF
--- a/src/main/kotlin/com/sparta/interparty/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/sparta/interparty/domain/user/controller/UserController.kt
@@ -1,6 +1,7 @@
 package com.sparta.interparty.domain.user.controller
 
 import com.sparta.interparty.domain.user.dto.req.SignoutReqDto
+import com.sparta.interparty.domain.user.dto.req.UpdateUserReqDto
 import com.sparta.interparty.domain.user.dto.res.OkResDto
 import com.sparta.interparty.domain.user.dto.res.UserResDto
 import com.sparta.interparty.domain.user.service.UserService
@@ -30,6 +31,15 @@ class UserController(
         val password = req.password
         userService.signout(userDetails, password)
         val res = OkResDto(okString = "회원 탈퇴가 완료되었습니다.")
+        return ResponseEntity.status(HttpStatus.OK).body(res)
+    }
+
+    @PatchMapping("/update")
+    fun updateUserInfo(@AuthenticationPrincipal userDetails: UserDetailsImpl,
+                       @RequestBody req: UpdateUserReqDto
+    ): ResponseEntity<OkResDto>{
+        userService.updateUserInfo(userDetails,req)
+        val res = OkResDto(okString = "회원 정보가 수정되었습니다.")
         return ResponseEntity.status(HttpStatus.OK).body(res)
     }
 }

--- a/src/main/kotlin/com/sparta/interparty/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/sparta/interparty/domain/user/controller/UserController.kt
@@ -35,10 +35,11 @@ class UserController(
     }
 
     @PatchMapping("/update")
-    fun updateUserInfo(@AuthenticationPrincipal userDetails: UserDetailsImpl,
-                       @RequestBody req: UpdateUserReqDto
-    ): ResponseEntity<OkResDto>{
-        userService.updateUserInfo(userDetails,req)
+    fun updateUserInfo(
+        @AuthenticationPrincipal userDetails: UserDetailsImpl,
+        @RequestBody req: UpdateUserReqDto
+    ): ResponseEntity<OkResDto> {
+        userService.updateUserInfo(userDetails, req)
         val res = OkResDto(okString = "회원 정보가 수정되었습니다.")
         return ResponseEntity.status(HttpStatus.OK).body(res)
     }

--- a/src/main/kotlin/com/sparta/interparty/domain/user/dto/req/UpdateUserReqDto.kt
+++ b/src/main/kotlin/com/sparta/interparty/domain/user/dto/req/UpdateUserReqDto.kt
@@ -1,0 +1,19 @@
+package com.sparta.interparty.domain.user.dto.req
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class UpdateUserReqDto(
+    @field:NotBlank
+    val currentPassword: String,
+
+    val newPassword: String? = null,
+
+    @field:Email
+    val email: String? = null,
+
+    val nickname: String? = null,
+
+    val phoneNumber: String? = null
+)

--- a/src/main/kotlin/com/sparta/interparty/domain/user/dto/req/UserReqDto.kt
+++ b/src/main/kotlin/com/sparta/interparty/domain/user/dto/req/UserReqDto.kt
@@ -1,4 +1,0 @@
-package com.sparta.interparty.domain.user.dto.req
-
-class UserReqDto {
-}

--- a/src/main/kotlin/com/sparta/interparty/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/sparta/interparty/domain/user/service/UserService.kt
@@ -1,6 +1,8 @@
 package com.sparta.interparty.domain.user.service
 
+import com.sparta.interparty.domain.user.dto.req.UpdateUserReqDto
 import com.sparta.interparty.domain.user.dto.res.UserResDto
+import com.sparta.interparty.domain.user.entity.User
 import com.sparta.interparty.domain.user.repo.UserRepository
 import com.sparta.interparty.global.exception.CustomException
 import com.sparta.interparty.global.exception.ExceptionResponseStatus
@@ -39,5 +41,25 @@ class UserService(
         val user = userDetails.getUser() ?: throw CustomException(ExceptionResponseStatus.USER_NOT_FOUND)
         user.isDeleted = true
         userRepository.save(user)
+    }
+
+    fun updateUserInfo(userDetails: UserDetailsImpl, req: UpdateUserReqDto) {
+        if (!passwordEncoder.matches(req.currentPassword, userDetails.password)) {
+            throw CustomException(ExceptionResponseStatus.INVALID_PASSWORD)
+        }
+        val user = userDetails.getUser() ?: throw CustomException(ExceptionResponseStatus.USER_NOT_FOUND)
+        setUserInfo(req, user)
+        userRepository.save(user)
+    }
+
+    private fun setUserInfo(req: UpdateUserReqDto, user: User) {
+        var isModified = false
+        req.newPassword?.let { user.password = passwordEncoder.encode(it); isModified = true }
+        req.email?.let { user.email = it; isModified = true }
+        req.nickname?.let { user.nickname = it; isModified = true }
+        req.phoneNumber?.let { user.phoneNumber = it; isModified = true }
+        if (!isModified) {
+            throw CustomException(ExceptionResponseStatus.INVALID_UPDATE_REQUEST)
+        }
     }
 }

--- a/src/main/kotlin/com/sparta/interparty/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/sparta/interparty/domain/user/service/UserService.kt
@@ -43,6 +43,7 @@ class UserService(
         userRepository.save(user)
     }
 
+    @Transactional
     fun updateUserInfo(userDetails: UserDetailsImpl, req: UpdateUserReqDto) {
         if (!passwordEncoder.matches(req.currentPassword, userDetails.password)) {
             throw CustomException(ExceptionResponseStatus.INVALID_PASSWORD)

--- a/src/main/kotlin/com/sparta/interparty/global/exception/ExceptionResponseStatus.kt
+++ b/src/main/kotlin/com/sparta/interparty/global/exception/ExceptionResponseStatus.kt
@@ -25,7 +25,8 @@ enum class ExceptionResponseStatus(val status: HttpStatus, val message: String) 
     // user
     DELETED_USER(HttpStatus.FORBIDDEN,"이미 탈퇴한 사용자입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.")
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    INVALID_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "수정할 정보가 없습니다.")
     ;
     // 열거형에서 바로 응답 엔티티 생성
     fun toResponseEntity(): ResponseEntity<ExceptionResponse> {


### PR DESCRIPTION
### #23 회원 정보 수정 기능 구현

---

- **회원 정보 수정 기능 추가**
  - 수정 가능한 필드: `password`, `email`, `nickname`, `phoneNumber`
  - 요청 DTO: 현재 비밀번호와 수정할 필드값을 포함
  - 응답 DTO: 수정 완료 메시지 반환
  - 서비스 로직: 입력받은 값만 반영, 모든 필드가 `null`인 경우 예외 처리 추가
  - 비밀번호 검증 로직 구현 (`PasswordEncoder.matches` 사용)

- **예외 처리**
  - 비밀번호 불일치: `INVALID_PASSWORD` 예외
  - 모든 필드가 `null`인 경우: `INVALID_UPDATE_REQUEST` 예외
